### PR TITLE
[1] Prompt for password on terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,37 @@ A tool for testing connectivity to SMB shares. With it you can:
 
 ### Calculate the MD5 hash of a file
 ```
-carnival md5 smb://user:password@address/sharename/path/to/file.txt
+$ carnival -u user md5 smb://address/sharename/path/to/file.txt
+Password:
 ```
 
 ### Copy a file from an SMB share to a local destination
 ```
-carnival cp smb://user:password@address/sharename/file.bin .
+$ carnival -u user cp smb://address/sharename/file.bin .
+Password:
 # OR rename it at the destination
-carnival cp smb://user:password@address/sharename/file.bin file.binary
+$ carnival -u user cp smb://address/sharename/file.bin file.binary
+Password:
 ```
 The `cp` command will tell you how long the transfer took and the average transfer speed.
 
 ### List the files in a directory
 ```
 # List the files at the root of the share
-carnival ls smb://user:password@address/sharename/
+$ carnival -u user ls smb://address/sharename/
+Password:
 
 # List the files in the 'Games' directory of the share
-carnival ls smb://user:password@address/sharename/Games
+$ carnival -u user ls smb://address/sharename/Games
+Password:
 ```
 
 ### Print the names of publicly visible SMB shares
 ```
-carnival shares smb://user:password@address
+$ carnival -u user shares smb://address
+Password:
 ```
 
-If a username and password are not included in the SMB url, carnival will authenticate as `guest` with an empty password.
+If the username is set through the `-u/--username` flag, the password will be prompted
+
+If no username is set, an anonymous session will be attempted

--- a/main.go
+++ b/main.go
@@ -35,6 +35,11 @@ func main() {
 			Name:  samba.FlagMapposix,
 			Usage: "use the equivalent of the samba 'mapposix' option",
 		},
+		&cli.StringFlag{
+			Aliases: []string{"u"},
+			Name:    samba.FlagUsername,
+			Usage:   "use the given username, the program will prompt for password",
+		},
 	}
 
 	prog.Commands = []*cli.Command{

--- a/pkg/samba/address_test.go
+++ b/pkg/samba/address_test.go
@@ -11,11 +11,12 @@ func TestNewURL(t *testing.T) {
 	t.Parallel()
 
 	testData := []struct {
-		input    string
+		inputURL string
+		creds    *Credentials
 		expected URL
 	}{
 		{
-			input: "smb://address/share/path",
+			inputURL: "smb://address/share/path",
 			expected: URL{
 				Address: "address:445",
 				Share:   "share",
@@ -23,14 +24,30 @@ func TestNewURL(t *testing.T) {
 			},
 		},
 		{
-			input: "smb://host.tld:3622/share",
+			inputURL: "smb://address/share/path",
+			creds: &Credentials{
+				Username: "foo",
+				Password: "bar",
+			},
+			expected: URL{
+				Address: "address:445",
+				Share:   "share",
+				Path:    "path",
+				Credentials: &Credentials{
+					Username: "foo",
+					Password: "bar",
+				},
+			},
+		},
+		{
+			inputURL: "smb://host.tld:3622/share",
 			expected: URL{
 				Address: "host.tld:3622",
 				Share:   "share",
 			},
 		},
 		{
-			input: "smb://user:foo@address.com/myshare/path/to/file.txt",
+			inputURL: "smb://user:foo@address.com/myshare/path/to/file.txt",
 			expected: URL{
 				Address: "address.com:445",
 				Share:   "myshare",
@@ -48,9 +65,16 @@ func TestNewURL(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := newURL(td.input)
+			actual, err := newURL(td.inputURL, td.creds)
 			require.NoError(t, err)
-			require.Equal(t, td.expected, actual)
+			require.Equal(t, td.expected.Address, actual.Address)
+			require.Equal(t, td.expected.Share, actual.Share)
+			require.Equal(t, td.expected.Path, actual.Path)
+			if td.expected.Credentials != nil {
+				require.NotNil(t, actual.Credentials)
+				require.Equal(t, td.expected.Credentials.Username, actual.Credentials.Username)
+				require.Equal(t, td.expected.Credentials.Password, actual.Credentials.Password)
+			}
 		})
 	}
 }

--- a/pkg/samba/cp.go
+++ b/pkg/samba/cp.go
@@ -118,8 +118,13 @@ func CopyTo(ctx *cli.Context) error {
 		return errors.New("2 arguments required")
 	}
 
+	creds, err := credentialsFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
 	srcPath := ctx.Args().Get(0)
-	u, err := newURL(ctx.Args().Get(1))
+	u, err := newURL(ctx.Args().Get(1), creds)
 	if err != nil {
 		return err
 	}

--- a/pkg/samba/flags.go
+++ b/pkg/samba/flags.go
@@ -4,4 +4,5 @@ const (
 	FlagDomain   = "domain"
 	FlagMapchars = "mapchars"
 	FlagMapposix = "mapposix"
+	FlagUsername = "username"
 )

--- a/pkg/samba/mount.go
+++ b/pkg/samba/mount.go
@@ -1,7 +1,6 @@
 package samba
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/cloudsoda/go-smb2"
@@ -20,10 +19,6 @@ func parseOptions(ctx *cli.Context) []smb2.MountOption {
 }
 
 func connect(u URL, domain string) (*smb2.Session, error) {
-	if u.Credentials == nil && domain == "" {
-		return nil, fmt.Errorf("--%s was specified but no user was specified in the URL", FlagDomain)
-	}
-
 	conn, err := net.Dial("tcp", u.Address)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit will:

1. Add a global flag `--username/-u <username>` that gets the username from it

2. If the flag is set, prompt for the password from `stdin` without echoing it (we can use [`golang.org/x/term`](https://pkg.go.dev/golang.org/x/term) package to do that)

3. If the flag is not set, go the old way

4. If no credentials are set, try to use anonymous session instead of failing

Rationale

See issue #1 description for a brief explanation